### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "eslint-plugin-mui-path-imports",
-  "version": "0.0.0",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-mui-path-imports",
-      "version": "0.0.0",
-      "license": "ISC",
+      "version": "0.0.3",
+      "license": "MIT",
       "dependencies": {
         "requireindex": "^1.2.0"
       },


### PR DESCRIPTION
この変更がpackage-lock.jsonに取り込まれていないため。
https://github.com/kajirikajiri/eslint-plugin-mui-path-imports/commit/466b53a60ed24bbb7df310c7bd2132cac51b1583

close https://github.com/kajirikajiri/eslint-plugin-mui-path-imports/issues/5
