### PR TITLE
Ignore import type

### DIFF
--- a/lib/rules/mui-path-imports.js
+++ b/lib/rules/mui-path-imports.js
@@ -29,10 +29,10 @@ module.exports = {
       ImportDeclaration(node) {
         const validationTargets = [
           "@mui/material", "@mui/icons-material", "@mui/lab", "@mui/joy",
-        ];
+        ]
         const allowNamedImports = [
           "Theme", "SvgIconTypeMap"
-        ];
+        ]
 
         const isTypeImport = node.importKind === 'type';
 
@@ -44,19 +44,19 @@ module.exports = {
           return
         }
         if (
-          node.source.value === "@mui/material" &&
+          node.source.value === '@mui/material' &&
           node.specifiers.length > 0 &&
-          node.specifiers.every((specifier) => {
+          node.specifiers.every(specifier => {
             return allowNamedImports.includes(specifier.local.name);
           })
         ) {
-          return;
+          return
         }
 
-        const hasError = node.specifiers.some((specifier) => {
+        const hasError = node.specifiers.some(specifier => {
           if (specifier.type !== "ImportDefaultSpecifier") return true;
-          return false;
-        });
+          return false
+        })
         if (hasError) {
           context.report({
             node,
@@ -77,17 +77,13 @@ module.exports = {
                 return allowNamedImports.includes(specifier.local.name);
               });
               if (b.length > 0) {
-                fixed.push(
-                  `import { ${b
-                    .map((bb) => bb.local.name)
-                    .join(', ')} } from "${node.source.value}";`
-                );
+                fixed.push(`import { ${b.map(bb => bb.local.name).join(", ")} } from "${node.source.value}";`)
               }
               return fixer.replaceText(node, fixed.join('\n'));
-            },
-          });
+            }
+          })
         }
-      },
+      }
     };
   },
 };

--- a/lib/rules/mui-path-imports.js
+++ b/lib/rules/mui-path-imports.js
@@ -13,51 +13,35 @@
  */
 module.exports = {
   meta: {
-    type: "problem", // `problem`, `suggestion`, or `layout`
+    type: 'problem', // `problem`, `suggestion`, or `layout`
     docs: {
       description: "rule",
       category: "Fill me in",
       recommended: false,
       url: null, // URL to the documentation page for this rule
     },
-    fixable: "code", // Or `code` or `whitespace`
-    schema: [
-      {
-        /*
-          ignoreImportTypeKeyword will allow you to ignore type imports. this is very handy when linting typescript files. 
-          It is recommended that it come from the top level of the library as well. 
-          This does not affect the tree shake given that types are removed on build time.
-          for example:
-          import type { TextFieldProps } from '@mui/material';
-        */
-        ignoreImportTypeKeyword: "boolean",
-      },
-    ], // Add a schema if the rule has options
+    fixable: 'code', // Or `code` or `whitespace`
+    schema: [], // Add a schema if the rule has options
   },
 
   create(context) {
     return {
       ImportDeclaration(node) {
         const validationTargets = [
-          "@mui/material",
-          "@mui/icons-material",
-          "@mui/lab",
-          "@mui/joy",
+          "@mui/material", "@mui/icons-material", "@mui/lab", "@mui/joy",
         ];
-        const allowNamedImports = ["Theme", "SvgIconTypeMap"];
-        /* 
-        
-        if is not allowed and import is type return false
-        if is not allowed and import iqs normal return true
-        if is allowed and import is normal return true
-        if is allowed and import is type return true
-        */
-        const ignoreImportTypeKeyword = context.options[0]
-          ? context.options[0].ignoreImportTypeKeyword
-          : false;
+        const allowNamedImports = [
+          "Theme", "SvgIconTypeMap"
+        ];
+
+        const isTypeImport = node.importKind === 'type';
+
+        if (isTypeImport) {
+          return
+        }
 
         if (!validationTargets.includes(node.source.value)) {
-          return;
+          return
         }
         if (
           node.source.value === "@mui/material" &&
@@ -69,16 +53,10 @@ module.exports = {
           return;
         }
 
-        const shouldLintTypeImports = !(
-          node.importKind === "type" && ignoreImportTypeKeyword
-        );
-
-        const hasError =
-          shouldLintTypeImports &&
-          node.specifiers.some((specifier) => {
-            if (specifier.type !== "ImportDefaultSpecifier") return true;
-            return false;
-          });
+        const hasError = node.specifiers.some((specifier) => {
+          if (specifier.type !== "ImportDefaultSpecifier") return true;
+          return false;
+        });
         if (hasError) {
           context.report({
             node,
@@ -102,10 +80,10 @@ module.exports = {
                 fixed.push(
                   `import { ${b
                     .map((bb) => bb.local.name)
-                    .join(", ")} } from "${node.source.value}";`
+                    .join(', ')} } from "${node.source.value}";`
                 );
               }
-              return fixer.replaceText(node, fixed.join("\n"));
+              return fixer.replaceText(node, fixed.join('\n'));
             },
           });
         }

--- a/lib/rules/mui-path-imports.js
+++ b/lib/rules/mui-path-imports.js
@@ -13,65 +13,89 @@
  */
 module.exports = {
   meta: {
-    type: 'problem', // `problem`, `suggestion`, or `layout`
+    type: "problem", // `problem`, `suggestion`, or `layout`
     docs: {
       description: "rule",
       category: "Fill me in",
       recommended: false,
       url: null, // URL to the documentation page for this rule
     },
-    fixable: 'code', // Or `code` or `whitespace`
-    schema: [], // Add a schema if the rule has options
+    fixable: "code", // Or `code` or `whitespace`
+    schema: [{ allowType: "boolean" }], // Add a schema if the rule has options
   },
 
   create(context) {
     return {
       ImportDeclaration(node) {
         const validationTargets = [
-          "@mui/material", "@mui/icons-material", "@mui/lab", "@mui/joy"
-        ]
-        const allowNamedImports = [
-          "Theme", "SvgIconTypeMap"
-        ]
+          "@mui/material",
+          "@mui/icons-material",
+          "@mui/lab",
+          "@mui/joy",
+        ];
+        const allowNamedImports = ["Theme", "SvgIconTypeMap"];
+        const isTypeActive = context.options[0]
+          ? context.options[0].allowType
+          : false;
+        // if is not allowed and import is type return false
+        // if is not allowed and import iqs normal return true
+        // if is allowed and import is normal return true
+        // if is allowed and import is type return true
+
         if (!validationTargets.includes(node.source.value)) {
-          return
+          return;
         }
         if (
-          node.source.value === '@mui/material' &&
+          node.source.value === "@mui/material" &&
           node.specifiers.length > 0 &&
-          node.specifiers.every(specifier => {
-            return allowNamedImports.includes(specifier.local.name)
+          node.specifiers.every((specifier) => {
+            return allowNamedImports.includes(specifier.local.name);
           })
         ) {
-          return
+          return;
         }
 
-        const hasError = node.specifiers.some(specifier => {
-          if (specifier.type !== "ImportDefaultSpecifier") return true
-          return false
-        })
+        const hasError = node.specifiers.some((specifier) => {
+          if (
+            specifier.type !== "ImportDefaultSpecifier" &&
+            !(node.importKind === "type" && isTypeActive)
+          )
+            return true;
+          return false;
+        });
+        console.log;
         if (hasError) {
           context.report({
             node,
             message: "error: !mui-toplevel-import",
             fix(fixer) {
-              const fixed = []
-              node.specifiers.filter((specifier) => {
-                return !allowNamedImports.includes(specifier.local.name)
-              }).forEach(specifier => {
-                fixed.push(`import ${specifier.local.name} from "${node.source.value}/${specifier.local.name}";`)
-              })
+              const fixed = [];
+              if (node.importKind === "type" && !isTypeActive) return null;
+              node.specifiers
+                .filter((specifier) => {
+                  return !allowNamedImports.includes(specifier.local.name);
+                })
+                .forEach((specifier) => {
+                  fixed.push(
+                    `import ${specifier.local.name} from "${node.source.value}/${specifier.local.name}";`
+                  );
+                });
               const b = node.specifiers.filter((specifier) => {
-                return allowNamedImports.includes(specifier.local.name)
-              })
+                return allowNamedImports.includes(specifier.local.name);
+              });
               if (b.length > 0) {
-                fixed.push(`import { ${b.map(bb => bb.local.name).join(", ")} } from "${node.source.value}";`)
+                fixed.push(
+                  `import { ${b
+                    .map((bb) => bb.local.name)
+                    .join(", ")} } from "${node.source.value}";`
+                );
               }
-              return fixer.replaceText(node, fixed.join("\n"))
-            }
-          })
+              console.log({ fixed });
+              return fixer.replaceText(node, fixed.join("\n"));
+            },
+          });
         }
-      }
+      },
     };
   },
 };

--- a/lib/rules/mui-path-imports.js
+++ b/lib/rules/mui-path-imports.js
@@ -28,7 +28,7 @@ module.exports = {
     return {
       ImportDeclaration(node) {
         const validationTargets = [
-          "@mui/material", "@mui/icons-material", "@mui/lab", "@mui/joy",
+          "@mui/material", "@mui/icons-material", "@mui/lab", "@mui/joy"
         ]
         const allowNamedImports = [
           "Theme", "SvgIconTypeMap"
@@ -47,14 +47,14 @@ module.exports = {
           node.source.value === '@mui/material' &&
           node.specifiers.length > 0 &&
           node.specifiers.every(specifier => {
-            return allowNamedImports.includes(specifier.local.name);
+            return allowNamedImports.includes(specifier.local.name)
           })
         ) {
           return
         }
 
         const hasError = node.specifiers.some(specifier => {
-          if (specifier.type !== "ImportDefaultSpecifier") return true;
+          if (specifier.type !== "ImportDefaultSpecifier") return true
           return false
         })
         if (hasError) {
@@ -62,24 +62,19 @@ module.exports = {
             node,
             message: "error: !mui-toplevel-import",
             fix(fixer) {
-              const fixed = [];
-              if (node.importKind === "type") return null;
-              node.specifiers
-                .filter((specifier) => {
-                  return !allowNamedImports.includes(specifier.local.name);
-                })
-                .forEach((specifier) => {
-                  fixed.push(
-                    `import ${specifier.local.name} from "${node.source.value}/${specifier.local.name}";`
-                  );
-                });
+              const fixed = []
+              node.specifiers.filter((specifier) => {
+                return !allowNamedImports.includes(specifier.local.name)
+              }).forEach(specifier => {
+                fixed.push(`import ${specifier.local.name} from "${node.source.value}/${specifier.local.name}";`)
+              })
               const b = node.specifiers.filter((specifier) => {
-                return allowNamedImports.includes(specifier.local.name);
-              });
+                return allowNamedImports.includes(specifier.local.name)
+              })
               if (b.length > 0) {
                 fixed.push(`import { ${b.map(bb => bb.local.name).join(", ")} } from "${node.source.value}";`)
               }
-              return fixer.replaceText(node, fixed.join('\n'));
+              return fixer.replaceText(node, fixed.join('\n'))
             }
           })
         }

--- a/lib/rules/mui-path-imports.js
+++ b/lib/rules/mui-path-imports.js
@@ -21,7 +21,18 @@ module.exports = {
       url: null, // URL to the documentation page for this rule
     },
     fixable: "code", // Or `code` or `whitespace`
-    schema: [{ allowType: "boolean" }], // Add a schema if the rule has options
+    schema: [
+      {
+        /*
+          ignoreImportTypeKeyword will allow you to ignore type imports. this is very handy when linting typescript files. 
+          It is recommended that it come from the top level of the library as well. 
+          This does not affect the tree shake given that types are removed on build time.
+          for example:
+          import type { TextFieldProps } from '@mui/material';
+        */
+        ignoreImportTypeKeyword: "boolean",
+      },
+    ], // Add a schema if the rule has options
   },
 
   create(context) {
@@ -34,13 +45,16 @@ module.exports = {
           "@mui/joy",
         ];
         const allowNamedImports = ["Theme", "SvgIconTypeMap"];
-        const isTypeActive = context.options[0]
-          ? context.options[0].allowType
+        /* 
+        
+        if is not allowed and import is type return false
+        if is not allowed and import iqs normal return true
+        if is allowed and import is normal return true
+        if is allowed and import is type return true
+        */
+        const ignoreImportTypeKeyword = context.options[0]
+          ? context.options[0].ignoreImportTypeKeyword
           : false;
-        // if is not allowed and import is type return false
-        // if is not allowed and import iqs normal return true
-        // if is allowed and import is normal return true
-        // if is allowed and import is type return true
 
         if (!validationTargets.includes(node.source.value)) {
           return;
@@ -55,22 +69,23 @@ module.exports = {
           return;
         }
 
-        const hasError = node.specifiers.some((specifier) => {
-          if (
-            specifier.type !== "ImportDefaultSpecifier" &&
-            !(node.importKind === "type" && isTypeActive)
-          )
-            return true;
-          return false;
-        });
-        console.log;
+        const shouldLintTypeImports = !(
+          node.importKind === "type" && ignoreImportTypeKeyword
+        );
+
+        const hasError =
+          shouldLintTypeImports &&
+          node.specifiers.some((specifier) => {
+            if (specifier.type !== "ImportDefaultSpecifier") return true;
+            return false;
+          });
         if (hasError) {
           context.report({
             node,
             message: "error: !mui-toplevel-import",
             fix(fixer) {
               const fixed = [];
-              if (node.importKind === "type" && !isTypeActive) return null;
+              if (node.importKind === "type") return null;
               node.specifiers
                 .filter((specifier) => {
                   return !allowNamedImports.includes(specifier.local.name);
@@ -90,7 +105,6 @@ module.exports = {
                     .join(", ")} } from "${node.source.value}";`
                 );
               }
-              console.log({ fixed });
               return fixer.replaceText(node, fixed.join("\n"));
             },
           });

--- a/lib/rules/mui-path-imports.js
+++ b/lib/rules/mui-path-imports.js
@@ -74,7 +74,7 @@ module.exports = {
               if (b.length > 0) {
                 fixed.push(`import { ${b.map(bb => bb.local.name).join(", ")} } from "${node.source.value}";`)
               }
-              return fixer.replaceText(node, fixed.join('\n'))
+              return fixer.replaceText(node, fixed.join("\n"))
             }
           })
         }

--- a/tests/lib/rules/mui-path-imports.js
+++ b/tests/lib/rules/mui-path-imports.js
@@ -49,7 +49,7 @@ ruleTester.run("rule", rule, {
     },
     {
       code: `import type { TextFieldProps as MuiTextFieldProps } from '@mui/material';`,
-      options: [{ allowType: true }],
+      options: [{ ignoreImportTypeKeyword: true }],
     },
     {
       code: `import type { TextFieldProps } from '@mui/material/Textfield';`,

--- a/tests/lib/rules/mui-path-imports.js
+++ b/tests/lib/rules/mui-path-imports.js
@@ -16,43 +16,42 @@ const rule = require("../../../lib/rules/mui-path-imports"),
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: require.resolve("@typescript-eslint/parser"),
+  parser: require.resolve('@typescript-eslint/parser'),
 });
 ruleTester.run("rule", rule, {
   valid: [
     {
-      code: `import Box from "@mui/material/Box";`,
+      code: `import Box from "@mui/material/Box";`
     },
     {
-      code: `import Add from "@mui/icons-material/Add";`,
+      code: `import Add from "@mui/icons-material/Add";`
     },
     {
-      code: `import TreeView from "@mui/lab/TreeView";`,
+      code: `import TreeView from "@mui/lab/TreeView";`
     },
     {
-      code: `import Button from "@mui/joy/Button";`,
+      code: `import Button from "@mui/joy/Button";`
     },
     {
-      code: `import { Theme } from "@mui/material";`,
+      code: `import { Theme } from "@mui/material";`
     },
     {
-      code: `import { SvgIconTypeMap } from "@mui/material";`,
+      code: `import { SvgIconTypeMap } from "@mui/material";`
     },
     {
-      code: `import { SvgIconTypeMap, Theme } from "@mui/material";`,
+      code: `import { SvgIconTypeMap, Theme } from "@mui/material";`
     },
     {
-      code: `import { Theme, SvgIconTypeMap } from "@mui/material";`,
+      code: `import { Theme, SvgIconTypeMap } from "@mui/material";`
     },
     {
-      code: `import { Other } from "other/package";`,
+      code: `import { Other } from "other/package";`
     },
     {
-      code: `import type { TextFieldProps as MuiTextFieldProps } from '@mui/material';`,
-      options: [{ ignoreImportTypeKeyword: true }],
+      code: `import type { TextFieldProps as MuiTextFieldProps } from '@mui/material';`
     },
     {
-      code: `import type { TextFieldProps } from '@mui/material/Textfield';`,
+      code: `import type { TextFieldProps } from '@mui/material/Textfield';`
     },
   ],
 
@@ -60,75 +59,70 @@ ruleTester.run("rule", rule, {
     {
       code: `import { Add } from "@mui/icons-material";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
-      output: `import Add from "@mui/icons-material/Add";`,
+      output: `import Add from "@mui/icons-material/Add";`
     },
     {
       code: `import { Box } from "@mui/material";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
-      output: `import Box from "@mui/material/Box";`,
+      output: `import Box from "@mui/material/Box";`
     },
     {
       code: `import { TreeView } from "@mui/lab";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
-      output: `import TreeView from "@mui/lab/TreeView";`,
+      output: `import TreeView from "@mui/lab/TreeView";`
     },
     {
       code: `import { Button } from "@mui/joy";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
-      output: `import Button from "@mui/joy/Button";`,
+      output: `import Button from "@mui/joy/Button";`
     },
     {
       code: `import { Add, Link } from "@mui/icons-material";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
       output: `import Add from "@mui/icons-material/Add";
-import Link from "@mui/icons-material/Link";`,
+import Link from "@mui/icons-material/Link";`
     },
     {
       code: `import { Box, Card } from "@mui/material";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
       output: `import Box from "@mui/material/Box";
-import Card from "@mui/material/Card";`,
+import Card from "@mui/material/Card";`
     },
     {
       code: `import { Box, Theme } from "@mui/material";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
       output: `import Box from "@mui/material/Box";
-import { Theme } from "@mui/material";`,
+import { Theme } from "@mui/material";`
     },
     {
       code: `import { TreeView, TreeItem } from "@mui/lab";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
       output: `import TreeView from "@mui/lab/TreeView";
-import TreeItem from "@mui/lab/TreeItem";`,
+import TreeItem from "@mui/lab/TreeItem";`
     },
     {
       code: `import { Button, Select } from "@mui/joy";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
       output: `import Button from "@mui/joy/Button";
-import Select from "@mui/joy/Select";`,
+import Select from "@mui/joy/Select";`
     },
     {
       code: `import { Box, Theme, SvgIconTypeMap } from "@mui/material";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
       output: `import Box from "@mui/material/Box";
-import { Theme, SvgIconTypeMap } from "@mui/material";`,
+import { Theme, SvgIconTypeMap } from "@mui/material";`
     },
     {
       code: `import { Theme, Box, SvgIconTypeMap } from "@mui/material";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
       output: `import Box from "@mui/material/Box";
-import { Theme, SvgIconTypeMap } from "@mui/material";`,
+import { Theme, SvgIconTypeMap } from "@mui/material";`
     },
     {
       code: `import { Theme, SvgIconTypeMap, Box } from "@mui/material";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
       output: `import Box from "@mui/material/Box";
-import { Theme, SvgIconTypeMap } from "@mui/material";`,
-    },
-    {
-      code: `import type { TextFieldProps } from '@mui/material';`,
-      errors: [{ message: "error: !mui-toplevel-import", type: "" }],
-      output: null,
+import { Theme, SvgIconTypeMap } from "@mui/material";`
     },
   ],
 });

--- a/tests/lib/rules/mui-path-imports.js
+++ b/tests/lib/rules/mui-path-imports.js
@@ -16,36 +16,43 @@ const rule = require("../../../lib/rules/mui-path-imports"),
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@typescript-eslint/parser'),
+  parser: require.resolve("@typescript-eslint/parser"),
 });
 ruleTester.run("rule", rule, {
   valid: [
     {
-      code: `import Box from "@mui/material/Box";`
+      code: `import Box from "@mui/material/Box";`,
     },
     {
-      code: `import Add from "@mui/icons-material/Add";`
+      code: `import Add from "@mui/icons-material/Add";`,
     },
     {
-      code: `import TreeView from "@mui/lab/TreeView";`
+      code: `import TreeView from "@mui/lab/TreeView";`,
     },
     {
-      code: `import Button from "@mui/joy/Button";`
+      code: `import Button from "@mui/joy/Button";`,
     },
     {
-      code: `import { Theme } from "@mui/material";`
+      code: `import { Theme } from "@mui/material";`,
     },
     {
-      code: `import { SvgIconTypeMap } from "@mui/material";`
+      code: `import { SvgIconTypeMap } from "@mui/material";`,
     },
     {
-      code: `import { SvgIconTypeMap, Theme } from "@mui/material";`
+      code: `import { SvgIconTypeMap, Theme } from "@mui/material";`,
     },
     {
-      code: `import { Theme, SvgIconTypeMap } from "@mui/material";`
+      code: `import { Theme, SvgIconTypeMap } from "@mui/material";`,
     },
     {
-      code: `import { Other } from "other/package";`
+      code: `import { Other } from "other/package";`,
+    },
+    {
+      code: `import type { TextFieldProps as MuiTextFieldProps } from '@mui/material';`,
+      options: [{ allowType: true }],
+    },
+    {
+      code: `import type { TextFieldProps } from '@mui/material/Textfield';`,
     },
   ],
 
@@ -53,22 +60,22 @@ ruleTester.run("rule", rule, {
     {
       code: `import { Add } from "@mui/icons-material";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
-      output: `import Add from "@mui/icons-material/Add";`
+      output: `import Add from "@mui/icons-material/Add";`,
     },
     {
       code: `import { Box } from "@mui/material";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
-      output: `import Box from "@mui/material/Box";`
+      output: `import Box from "@mui/material/Box";`,
     },
     {
       code: `import { TreeView } from "@mui/lab";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
-      output: `import TreeView from "@mui/lab/TreeView";`
+      output: `import TreeView from "@mui/lab/TreeView";`,
     },
     {
       code: `import { Button } from "@mui/joy";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
-      output: `import Button from "@mui/joy/Button";`
+      output: `import Button from "@mui/joy/Button";`,
     },
     {
       code: `import { Add, Link } from "@mui/icons-material";`,
@@ -80,7 +87,7 @@ import Link from "@mui/icons-material/Link";`,
       code: `import { Box, Card } from "@mui/material";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
       output: `import Box from "@mui/material/Box";
-import Card from "@mui/material/Card";`
+import Card from "@mui/material/Card";`,
     },
     {
       code: `import { Box, Theme } from "@mui/material";`,
@@ -104,19 +111,24 @@ import Select from "@mui/joy/Select";`,
       code: `import { Box, Theme, SvgIconTypeMap } from "@mui/material";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
       output: `import Box from "@mui/material/Box";
-import { Theme, SvgIconTypeMap } from "@mui/material";`
+import { Theme, SvgIconTypeMap } from "@mui/material";`,
     },
     {
       code: `import { Theme, Box, SvgIconTypeMap } from "@mui/material";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
       output: `import Box from "@mui/material/Box";
-import { Theme, SvgIconTypeMap } from "@mui/material";`
+import { Theme, SvgIconTypeMap } from "@mui/material";`,
     },
     {
       code: `import { Theme, SvgIconTypeMap, Box } from "@mui/material";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
       output: `import Box from "@mui/material/Box";
-import { Theme, SvgIconTypeMap } from "@mui/material";`
+import { Theme, SvgIconTypeMap } from "@mui/material";`,
+    },
+    {
+      code: `import type { TextFieldProps } from '@mui/material';`,
+      errors: [{ message: "error: !mui-toplevel-import", type: "" }],
+      output: null,
     },
   ],
 });

--- a/tests/lib/rules/mui-path-imports.js
+++ b/tests/lib/rules/mui-path-imports.js
@@ -80,7 +80,7 @@ ruleTester.run("rule", rule, {
       code: `import { Add, Link } from "@mui/icons-material";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
       output: `import Add from "@mui/icons-material/Add";
-import Link from "@mui/icons-material/Link";`
+import Link from "@mui/icons-material/Link";`,
     },
     {
       code: `import { Box, Card } from "@mui/material";`,
@@ -92,13 +92,13 @@ import Card from "@mui/material/Card";`
       code: `import { Box, Theme } from "@mui/material";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
       output: `import Box from "@mui/material/Box";
-import { Theme } from "@mui/material";`
+import { Theme } from "@mui/material";`,
     },
     {
       code: `import { TreeView, TreeItem } from "@mui/lab";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
       output: `import TreeView from "@mui/lab/TreeView";
-import TreeItem from "@mui/lab/TreeItem";`
+import TreeItem from "@mui/lab/TreeItem";`,
     },
     {
       code: `import { Button, Select } from "@mui/joy";`,

--- a/tests/lib/rules/mui-path-imports.js
+++ b/tests/lib/rules/mui-path-imports.js
@@ -104,7 +104,7 @@ import TreeItem from "@mui/lab/TreeItem";`,
       code: `import { Button, Select } from "@mui/joy";`,
       errors: [{ message: "error: !mui-toplevel-import", type: "" }],
       output: `import Button from "@mui/joy/Button";
-import Select from "@mui/joy/Select";`
+import Select from "@mui/joy/Select";`,
     },
     {
       code: `import { Box, Theme, SvgIconTypeMap } from "@mui/material";`,


### PR DESCRIPTION
I'm creating this PR to not lint when `import type` is used due to it is [recommended](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export)  that it come from the top level of the library as well. This does not affect the tree shake given that types are removed on build time.